### PR TITLE
[normalizeParagraph] Normalizando parágrafos.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import compose from './compose';
 import uncouple from 'uncouple';
 
 const { join } = uncouple(Array);
-const { normalize, replace, trim, toLowerCase: lowercase } = uncouple(String);
+const { normalize, replace, trim, toLowerCase: lowercase, toUpperCase, indexOf } = uncouple(String);
 
 const WHITESPACE = ' ';
 
@@ -30,6 +30,20 @@ export const normalizeWhitespaces = compose(
 export const normalizeDiacritics = compose(
   (value) => replace(value, /[\u0080-\uF8FF]/g, ''),
   (value) => normalize(value, 'NFKD')
+);
+
+/**
+ * Normalize paragraph.
+ * @example ```js
+ * ('era uma vez no mundo encantado') => 'Era um vez no mundo encantado.'
+ * ```
+ * @param {string} value
+ * @returns {string}
+ */
+export const normalizeParagraph = compose(
+  normalizeWhitespaces,
+  (value) => replace( value, value[0], toUpperCase(value[0]) ),
+  (value) => value[ value.length-1 ] === '.' ? value : value+"."
 );
 
 /**

--- a/test/index.text.js
+++ b/test/index.text.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import normalizeText, { normalizeWhitespaces, normalizeDiacritics } from '../'
+import normalizeText, { normalizeWhitespaces, normalizeDiacritics, normalizeParagraph } from '../'
 
 test('normalizeWhitespaces -> Normalizes string whitespaces', (context) => {
   context.is(
@@ -27,5 +27,12 @@ test('normalizeText -> Merge text and compose other API functions', (context) =>
   context.is(
     normalizeText(['     Olá, \n', 'Tudo bem     com você\t?']),
     'ola, tudo bem com voce ?'
+  )
+})
+
+test('normalizeParagraph -> normalizes a string into a paragraph', (context) => {
+  context.is(
+    normalizeParagraph('era uma vez no mundo encantado'),
+    'Era uma vez no mundo encantado.'
   )
 })


### PR DESCRIPTION
Algumas vezes eu recebo textos de clientes e/ou documentos que deveriam ser parágrafos, porém estão sem pontuação e sem começar com maiúscula.

normalizeParagraph() faz isso.