### PR TITLE
add types entry to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
       {
         "import": "./dist/index.mjs",
         "require": "./dist/index.cjs",
-        "default": "./dist/index.js"
+        "default": "./dist/index.js",
+        "types": "./types/index.d.ts"
       },
       "./dist/index.js"
     ]


### PR DESCRIPTION
hilariously i just fixed this in another package (https://github.com/RobinTail/express-zod-api/pull/534), looks like this isn't super common knowledge yet since `nodenext` module resolution isn't used much yet

tl;dr when using `nodenext` module resolution in typescript, if there's an `exports` key it just ignores the top-level `types` key in your package.json and so if you don't _also_ specify a `types` key in your `exports` then it'll fail to resolve typescript typings

i think the one exception here is if your typescript typings were colocated with your ESM files but in this case you've got them in a separate `types` folder :)

didn't see any contributors guidelines so lmk if I missed anything! but it's a relatively trivial change so I imagine it's fine